### PR TITLE
include include.html in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "git@github.com:EkstraBladetUdvikling/eb-cmp.git",
   "author": "tegner <jesper.h.tegner@jppol.dk>",
   "files": [
-    "./types"
+    "./types",
+    "./include.html"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Jeg har brug for at [include.html](https://github.com/EkstraBladetUdvikling/eb-cmp/blob/master/include.html) kommer med i npm pakken så jeg også kan inkludere den i en sveltekit app